### PR TITLE
ci: Upgrade runner versions

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -12,7 +12,7 @@ runs:
       run: echo "${HOME}/.alire/bin" >> "${GITHUB_PATH}"
 
     - name: Cache Alire dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.cache/alire
@@ -23,7 +23,7 @@ runs:
           ${{ runner.os }}-alire-
 
     - name: Cache ROM downloads
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: tests/.rom-cache/downloads
         key: ${{ runner.os }}-rom-downloads-${{ hashFiles('tests/assets/roms_manifest.toml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GNATFORMAT_BUNDLE_ARTIFACT: gnatformat-bundle-ubuntu
   GNATFORMAT_BUNDLE_ARCHIVE: gnatformat-ubuntu.tar.zst
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Load test shard matrix
         id: matrix
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Shared CI setup
         uses: ./.github/actions/ci-setup
@@ -112,7 +112,7 @@ jobs:
 
       - name: Upload gnatformat bundle
         if: ${{ steps.restore_gnatformat_bundle.outputs.restored != 'true' && github.event_name == 'push' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.GNATFORMAT_BUNDLE_ARTIFACT }}
           path: ${{ runner.temp }}/${{ env.GNATFORMAT_BUNDLE_ARCHIVE }}
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Shared CI setup
         uses: ./.github/actions/ci-setup
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Shared CI setup
         uses: ./.github/actions/ci-setup
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload shard JUnit XML
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pytest-shard-${{ matrix.index }}
           path: ${{ runner.temp }}/pytest-shard-${{ matrix.index }}.xml
@@ -207,7 +207,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GNATFORMAT_BUNDLE_ARTIFACT: gnatformat-bundle-ubuntu
   GNATFORMAT_BUNDLE_ARCHIVE: gnatformat-ubuntu.tar.zst
 

--- a/.github/workflows/publish-gnatformat-bundle.yml
+++ b/.github/workflows/publish-gnatformat-bundle.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Shared CI setup
         uses: ./.github/actions/ci-setup
@@ -30,7 +30,7 @@ jobs:
           tar --zstd -cf "${RUNNER_TEMP}/${GNATFORMAT_BUNDLE_ARCHIVE}" -C "${HOME}" .alire
 
       - name: Upload gnatformat bundle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.GNATFORMAT_BUNDLE_ARTIFACT }}
           path: ${{ runner.temp }}/${{ env.GNATFORMAT_BUNDLE_ARCHIVE }}

--- a/.github/workflows/publish-gnatformat-bundle.yml
+++ b/.github/workflows/publish-gnatformat-bundle.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GNATFORMAT_BUNDLE_ARTIFACT: gnatformat-bundle-ubuntu
   GNATFORMAT_BUNDLE_ARCHIVE: gnatformat-ubuntu.tar.zst
 

--- a/.github/workflows/publish-gnatformat-bundle.yml
+++ b/.github/workflows/publish-gnatformat-bundle.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   GNATFORMAT_BUNDLE_ARTIFACT: gnatformat-bundle-ubuntu
   GNATFORMAT_BUNDLE_ARCHIVE: gnatformat-ubuntu.tar.zst
 


### PR DESCRIPTION
An unsuccessful attempt to get rid of these warnings:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Which are ultimately caused by the `setup-alire@v5` runner relying on Node.js 20 and being in need of a new version.

Still useful to update some of the runners, though.