### PR TITLE
feat: Game Boy Camera cart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ it rewrites files you should `git add` them and re-run the commit.
 
 ### What works
 - Full CPU emulation (Passes Blargg's CPU instruction tests)
-- Plain, MBC1, MBC2, MBC3 cartridge types with saves and MBC3 RTC support
+- Plain, MBC1, MBC2, MBC3 and Pocket Camera cartridge types with saves and MBC3 RTC support
 - Joypad
 - Timer
 - Background Layer

--- a/core/carts/README.md
+++ b/core/carts/README.md
@@ -36,7 +36,7 @@ Ues [BGB's 512 Byte file format spec](http://bgb.bircd.org/mbc2save.html) for fi
 Fully supported including its MBC30 (up to 8 RAM banks instead of 4) variant and the RTC (Real Time Clock). It uses [BGB's file format spec](http://bgb.bircd.org/rtcsave.html) to save RAM and RTC data. It's able to read both 32 and 64 bit RTC file formats, although saves will always be performed in 64 bit. The state is synchronized with the CPU clock once per frame, so if emulation does not happen in realtime that's accurately reflected in the RTC behavior.
 
 #### Pocket Camera / GB Camera (1MB ROM / 128kB RAM)
-The controller is supported, including its MBC3-like ROM/RAM banking, register window selection, capture busy timing and battery-backed RAM behavior. The actual camera sensor pipeline is currently stubbed with a deterministic static test pattern written to the cartridge RAM when a capture completes.
+The controller is supported, including its MBC3-like ROM/RAM banking, register window selection, capture busy timing and battery-backed RAM behavior. Captured image data is supplied through the library camera-provider API; if the client does not attach one, a deterministic static test pattern is written to cartridge RAM when a capture completes.
 
 ### Unsupported
 The following cartridge types are currently unsupported: MBC5, MBC6, HuC1, HuC3, MM01, MBC1 based multicarts. Aside from MBC5, all of these are very rare and not a priority to implement. MBC5 is used by most GB Color carts and should be trivial to add support for with the current architecture.

--- a/core/carts/README.md
+++ b/core/carts/README.md
@@ -35,8 +35,11 @@ Ues [BGB's 512 Byte file format spec](http://bgb.bircd.org/mbc2save.html) for fi
 #### MBC3 (Max 2MB ROM / 64kB RAM or 128kB RAM for MBC30 / RTC)
 Fully supported including its MBC30 (up to 8 RAM banks instead of 4) variant and the RTC (Real Time Clock). It uses [BGB's file format spec](http://bgb.bircd.org/rtcsave.html) to save RAM and RTC data. It's able to read both 32 and 64 bit RTC file formats, although saves will always be performed in 64 bit. The state is synchronized with the CPU clock once per frame, so if emulation does not happen in realtime that's accurately reflected in the RTC behavior.
 
+#### Pocket Camera / GB Camera (1MB ROM / 128kB RAM)
+The controller is supported, including its MBC3-like ROM/RAM banking, register window selection, capture busy timing and battery-backed RAM behavior. The actual camera sensor pipeline is currently stubbed with a deterministic static test pattern written to the cartridge RAM when a capture completes.
+
 ### Unsupported
-The following cartridge types are currently unsupported: MBC5, MBC6, GB Camera, HuC1, HuC3, MM01, MBC1 based multicarts. Aside from MBC5, all of these are very rare and not a priority to implement. MBC5 is used by most GB Color carts and should be trivial to add support for with the current architecture.
+The following cartridge types are currently unsupported: MBC5, MBC6, HuC1, HuC3, MM01, MBC1 based multicarts. Aside from MBC5, all of these are very rare and not a priority to implement. MBC5 is used by most GB Color carts and should be trivial to add support for with the current architecture.
 
 ## Mixins
 Mixins allow the concrete cartrige implementations to pick and choose which components to support without having to re-define the implementation of the Cart's interface methods.

--- a/core/carts/gade-carts-camera-constructors.adb
+++ b/core/carts/gade-carts-camera-constructors.adb
@@ -1,0 +1,47 @@
+with Gade.Carts.Constructors;
+with Gade.Carts.Mem.RAM; use Gade.Carts.Mem.RAM;
+with Gade.Carts.Mixins.MBC.Constructors;
+
+package body Gade.Carts.Camera.Constructors is
+   package MBC_Constructors is new MBC_Mixin.Constructors;
+
+   procedure Initialize
+     (C           : out Camera_Cart'Class;
+      ROM_Content : ROM_Content_Access;
+      Header      : Cart_Header;
+      RAM_Path    : String;
+      Logger      : Gade.Logging.Logger_Access);
+
+   function Create
+     (ROM_Content : ROM_Content_Access;
+      Header      : Cart_Header;
+      RAM_Path    : String;
+      Logger      : Gade.Logging.Logger_Access) return Camera_Cart_NN_Access
+   is
+      Result : constant Camera_Cart_NN_Access := new Camera_Cart;
+   begin
+      Initialize (Result.all, ROM_Content, Header, RAM_Path, Logger);
+      return Result;
+   end Create;
+
+   procedure Initialize
+     (C           : out Camera_Cart'Class;
+      ROM_Content : ROM_Content_Access;
+      Header      : Cart_Header;
+      RAM_Path    : String;
+      Logger      : Gade.Logging.Logger_Access)
+   is
+      Has_Battery : constant Boolean :=
+        Cart_Type_Info_For_Cart (Header.Cart_Type).Battery;
+      RAM_Content : constant RAM_Content_Access :=
+        Create
+          (Header.RAM_Size,
+           ROM_RAM_Mixin.Banked_RAM_Mixin.Banked_RAM_Spaces.Max_Content_Size);
+      Savable     : constant Boolean := Has_Battery and then RAM_Content /= null;
+   begin
+      Gade.Carts.Constructors.Initialize (Cart (C), RAM_Path, Savable, Logger);
+      MBC_Constructors.Initialize (C, ROM_Content, RAM_Content);
+      Reset (C);
+   end Initialize;
+
+end Gade.Carts.Camera.Constructors;

--- a/core/carts/gade-carts-camera-constructors.adb
+++ b/core/carts/gade-carts-camera-constructors.adb
@@ -1,4 +1,5 @@
 with Gade.Carts.Constructors;
+with Gade.Camera;
 with Gade.Carts.Mem.RAM; use Gade.Carts.Mem.RAM;
 with Gade.Carts.Mixins.MBC.Constructors;
 
@@ -41,6 +42,7 @@ package body Gade.Carts.Camera.Constructors is
    begin
       Gade.Carts.Constructors.Initialize (Cart (C), RAM_Path, Savable, Logger);
       MBC_Constructors.Initialize (C, ROM_Content, RAM_Content);
+      C.Provider := Gade.Camera.Default_Provider;
       Reset (C);
    end Initialize;
 

--- a/core/carts/gade-carts-camera-constructors.ads
+++ b/core/carts/gade-carts-camera-constructors.ads
@@ -1,0 +1,12 @@
+with Gade.Carts.Mem.ROM; use Gade.Carts.Mem.ROM;
+with Gade.Logging;
+
+package Gade.Carts.Camera.Constructors is
+
+   function Create
+     (ROM_Content : ROM_Content_Access;
+      Header      : Cart_Header;
+      RAM_Path    : String;
+      Logger      : Gade.Logging.Logger_Access) return Camera_Cart_NN_Access;
+
+end Gade.Carts.Camera.Constructors;

--- a/core/carts/gade-carts-camera.adb
+++ b/core/carts/gade-carts-camera.adb
@@ -1,13 +1,11 @@
 package body Gade.Carts.Camera is
+   use type Gade.Camera.Provider_Access;
+
    package Banked_RAM_Mixin renames ROM_RAM_Mixin.Banked_RAM_Mixin;
 
    Pattern_Base_Offset : constant := 16#0100#;
-   Pattern_Height      : constant := 112;
-   Pattern_Width       : constant := 128;
 
    function Capture_Cycles (C : Camera_Cart) return M_Cycle_Count;
-
-   function Pattern_Color (X : Natural; Y : Natural) return Byte;
 
    function Register_Index (Address : External_RAM_IO_Address) return Natural;
 
@@ -17,7 +15,7 @@ package body Gade.Carts.Camera is
 
    procedure Stop_Capture (C : in out Camera_Cart);
 
-   procedure Write_Pattern (C : in out Camera_Cart);
+   procedure Write_Captured_Frame (C : in out Camera_Cart);
 
    function Capture_Cycles (C : Camera_Cart) return M_Cycle_Count is
       Exposure_Steps : constant Natural :=
@@ -43,22 +41,8 @@ package body Gade.Carts.Camera is
    begin
       C.Capture_Active := False;
       C.Capture_Cycles_Left := 0;
-      Write_Pattern (C);
+      Write_Captured_Frame (C);
    end Complete_Capture;
-
-   function Pattern_Color (X : Natural; Y : Natural) return Byte is
-      In_Border : constant Boolean :=
-        X < 8
-        or else X >= Pattern_Width - 8
-        or else Y < 8
-        or else Y >= Pattern_Height - 8;
-   begin
-      if In_Border then
-         return 3;
-      else
-         return Byte ((X / 32) mod 4);
-      end if;
-   end Pattern_Color;
 
    function Register_Index (Address : External_RAM_IO_Address) return Natural is
    begin
@@ -134,6 +118,13 @@ package body Gade.Carts.Camera is
    end Resume_Capture;
 
    overriding
+   procedure Set_Camera_Provider
+     (C : in out Camera_Cart; Provider : Gade.Camera.Provider_Access) is
+   begin
+      C.Provider := (if Provider = null then Gade.Camera.Default_Provider else Provider);
+   end Set_Camera_Provider;
+
+   overriding
    procedure Select_Bank
      (C : in out Camera_Cart; Address : Bank_Select_Address; Value : Byte) is
    begin
@@ -182,29 +173,31 @@ package body Gade.Carts.Camera is
       end if;
    end Write_RAM;
 
-   procedure Write_Pattern (C : in out Camera_Cart) is
+   procedure Write_Captured_Frame (C : in out Camera_Cart) is
       Address         : External_RAM_IO_Address;
+      Frame           : Gade.Camera.Bitmap;
       High            : Byte;
       Low             : Byte;
       Original_Bank   : constant Banked_RAM_Mixin.Banked_RAM_Spaces.Bank_Index :=
         C.Selected_RAM_Bank;
       Original_Select : constant Boolean := C.Registers_Selected;
       Shade           : Byte;
-      X               : Natural;
-      Y               : Natural;
    begin
+      Gade.Camera.Capture_Frame (C.Provider, Frame);
       Banked_RAM_Mixin.Select_RAM_Bank (Banked_RAM_Mixin.Banked_RAM_Cart (C), 0);
 
-      for Tile_Y in 0 .. (Pattern_Height / 8) - 1 loop
-         for Tile_X in 0 .. (Pattern_Width / 8) - 1 loop
+      for Tile_Y in 0 .. (Gade.Camera.Capture_Height / 8) - 1 loop
+         for Tile_X in 0 .. (Gade.Camera.Capture_Width / 8) - 1 loop
             for Row in 0 .. 7 loop
                High := 16#00#;
                Low := 16#00#;
 
                for Col in 0 .. 7 loop
-                  X := Tile_X * 8 + Col;
-                  Y := Tile_Y * 8 + Row;
-                  Shade := Pattern_Color (X, Y);
+                  Shade :=
+                    Byte
+                      (Frame
+                         (Gade.Camera.Row_Index (Tile_Y * 8 + Row),
+                          Gade.Camera.Column_Index (Tile_X * 8 + Col)));
                   if (Shade and 16#01#) /= 0 then
                      Low := Low or 2**(7 - Col);
                   end if;
@@ -227,7 +220,7 @@ package body Gade.Carts.Camera is
       Banked_RAM_Mixin.Select_RAM_Bank
         (Banked_RAM_Mixin.Banked_RAM_Cart (C), Original_Bank);
       C.Registers_Selected := Original_Select;
-   end Write_Pattern;
+   end Write_Captured_Frame;
 
    procedure Write_Register
      (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : Byte)

--- a/core/carts/gade-carts-camera.adb
+++ b/core/carts/gade-carts-camera.adb
@@ -41,7 +41,14 @@ package body Gade.Carts.Camera is
    begin
       C.Capture_Active := False;
       C.Capture_Cycles_Left := 0;
-      Write_Captured_Frame (C);
+      begin
+         Write_Captured_Frame (C);
+      exception
+         when others =>
+            Gade.Camera.Set_Capture_Active (C.Provider, False);
+            raise;
+      end;
+      Gade.Camera.Set_Capture_Active (C.Provider, False);
    end Complete_Capture;
 
    function Register_Index (Address : External_RAM_IO_Address) return Natural is
@@ -93,6 +100,10 @@ package body Gade.Carts.Camera is
    overriding
    procedure Reset (C : in out Camera_Cart) is
    begin
+      if C.Capture_Active then
+         Gade.Camera.Set_Capture_Active (C.Provider, False);
+      end if;
+
       MBC_Cart (C).Reset;
       Banked_RAM_Mixin.Enable_RAM (Banked_RAM_Mixin.Banked_RAM_Cart (C), True);
       Banked_RAM_Mixin.Select_RAM_Bank (Banked_RAM_Mixin.Banked_RAM_Cart (C), 0);
@@ -114,14 +125,26 @@ package body Gade.Carts.Camera is
          C.Capture_Cycles_Left := Capture_Cycles (C);
       end if;
 
+      Gade.Camera.Set_Capture_Active (C.Provider, True);
       C.Capture_Active := True;
    end Resume_Capture;
 
    overriding
    procedure Set_Camera_Provider
-     (C : in out Camera_Cart; Provider : Gade.Camera.Provider_Access) is
+     (C : in out Camera_Cart; Provider : Gade.Camera.Provider_Access)
+   is
+      New_Provider : constant Gade.Camera.Provider_Access :=
+        (if Provider = null then Gade.Camera.Default_Provider else Provider);
    begin
-      C.Provider := (if Provider = null then Gade.Camera.Default_Provider else Provider);
+      if C.Capture_Active then
+         Gade.Camera.Set_Capture_Active (C.Provider, False);
+      end if;
+
+      C.Provider := New_Provider;
+
+      if C.Capture_Active then
+         Gade.Camera.Set_Capture_Active (C.Provider, True);
+      end if;
    end Set_Camera_Provider;
 
    overriding
@@ -157,6 +180,9 @@ package body Gade.Carts.Camera is
 
    procedure Stop_Capture (C : in out Camera_Cart) is
    begin
+      if C.Capture_Active then
+         Gade.Camera.Set_Capture_Active (C.Provider, False);
+      end if;
       C.Capture_Active := False;
    end Stop_Capture;
 

--- a/core/carts/gade-carts-camera.adb
+++ b/core/carts/gade-carts-camera.adb
@@ -1,0 +1,249 @@
+package body Gade.Carts.Camera is
+   package Banked_RAM_Mixin renames ROM_RAM_Mixin.Banked_RAM_Mixin;
+
+   Pattern_Base_Offset : constant := 16#0100#;
+   Pattern_Height      : constant := 112;
+   Pattern_Width       : constant := 128;
+
+   function Capture_Cycles (C : Camera_Cart) return M_Cycle_Count;
+
+   function Pattern_Color (X : Natural; Y : Natural) return Byte;
+
+   function Register_Index (Address : External_RAM_IO_Address) return Natural;
+
+   procedure Complete_Capture (C : in out Camera_Cart);
+
+   procedure Resume_Capture (C : in out Camera_Cart);
+
+   procedure Stop_Capture (C : in out Camera_Cart);
+
+   procedure Write_Pattern (C : in out Camera_Cart);
+
+   function Capture_Cycles (C : Camera_Cart) return M_Cycle_Count is
+      Exposure_Steps : constant Natural :=
+        Natural (Word (C.Registers (2)) * 2**8 + Word (C.Registers (3)));
+      N_Bit_Cycles   : constant M_Cycle_Count :=
+        (if (C.Registers (1) and 16#80#) = 0 then 512 else 0);
+   begin
+      return 32_446 + N_Bit_Cycles + M_Cycle_Count (16 * Exposure_Steps);
+   end Capture_Cycles;
+
+   overriding
+   procedure Enable_RAM (C : in out Camera_Cart; Enable : Boolean) is
+   begin
+      C.RAM_Write_Enabled := Enable;
+      Banked_RAM_Mixin.Enable_RAM (Banked_RAM_Mixin.Banked_RAM_Cart (C), True);
+      if not C.Registers_Selected then
+         Banked_RAM_Mixin.Select_RAM_Bank
+           (Banked_RAM_Mixin.Banked_RAM_Cart (C), C.Selected_RAM_Bank);
+      end if;
+   end Enable_RAM;
+
+   procedure Complete_Capture (C : in out Camera_Cart) is
+   begin
+      C.Capture_Active := False;
+      C.Capture_Cycles_Left := 0;
+      Write_Pattern (C);
+   end Complete_Capture;
+
+   function Pattern_Color (X : Natural; Y : Natural) return Byte is
+      In_Border : constant Boolean :=
+        X < 8
+        or else X >= Pattern_Width - 8
+        or else Y < 8
+        or else Y >= Pattern_Height - 8;
+   begin
+      if In_Border then
+         return 3;
+      else
+         return Byte ((X / 32) mod 4);
+      end if;
+   end Pattern_Color;
+
+   function Register_Index (Address : External_RAM_IO_Address) return Natural is
+   begin
+      return Natural (Address - External_RAM_IO_Address'First) mod Register_Mirror_Size;
+   end Register_Index;
+
+   overriding
+   procedure Read_RAM
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : out Byte) is
+   begin
+      if C.Registers_Selected then
+         Read_Register (C, Address, V);
+      elsif C.Capture_Active then
+         V := 16#00#;
+      else
+         Banked_RAM_Mixin.Read_RAM (Banked_RAM_Mixin.Banked_RAM_Cart (C), Address, V);
+      end if;
+   end Read_RAM;
+
+   procedure Read_Register
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : out Byte)
+   is
+      Idx : constant Natural := Register_Index (Address);
+   begin
+      if Idx = 0 then
+         V :=
+           (C.Registers (0) and Register_0_Read_Mask)
+           or (if C.Capture_Active then 16#01# else 16#00#);
+      else
+         V := 16#00#;
+      end if;
+   end Read_Register;
+
+   overriding
+   procedure Report_Cycles (C : in out Camera_Cart; Cycles : M_Cycle_Count) is
+   begin
+      if not C.Capture_Active then
+         return;
+      end if;
+
+      if Cycles >= C.Capture_Cycles_Left then
+         Complete_Capture (C);
+      else
+         C.Capture_Cycles_Left := C.Capture_Cycles_Left - Cycles;
+      end if;
+   end Report_Cycles;
+
+   overriding
+   procedure Reset (C : in out Camera_Cart) is
+   begin
+      MBC_Cart (C).Reset;
+      Banked_RAM_Mixin.Enable_RAM (Banked_RAM_Mixin.Banked_RAM_Cart (C), True);
+      Banked_RAM_Mixin.Select_RAM_Bank (Banked_RAM_Mixin.Banked_RAM_Cart (C), 0);
+      C.Capture_Active := False;
+      C.Capture_Cycles_Left := 0;
+      C.RAM_Write_Enabled := False;
+      C.Registers := [others => 0];
+      C.Registers_Selected := False;
+      C.Selected_RAM_Bank := 0;
+   end Reset;
+
+   procedure Resume_Capture (C : in out Camera_Cart) is
+   begin
+      if C.Capture_Active then
+         return;
+      end if;
+
+      if C.Capture_Cycles_Left = 0 then
+         C.Capture_Cycles_Left := Capture_Cycles (C);
+      end if;
+
+      C.Capture_Active := True;
+   end Resume_Capture;
+
+   overriding
+   procedure Select_Bank
+     (C : in out Camera_Cart; Address : Bank_Select_Address; Value : Byte) is
+   begin
+      if Address in ROM_Bank_Select_Address then
+         Select_ROM_Bank (C, Value);
+      elsif Address in RAM_Bank_Select_Address then
+         Select_RAM_Bank (C, Value);
+      end if;
+   end Select_Bank;
+
+   procedure Select_RAM_Bank (C : in out Camera_Cart; Value : Byte) is
+   begin
+      if (Value and RAM_Select_Bit) /= 0 then
+         C.Registers_Selected := True;
+      else
+         C.Registers_Selected := False;
+         C.Selected_RAM_Bank :=
+           ROM_RAM_Mixin.Banked_RAM_Mixin.Banked_RAM_Spaces.Bank_Index
+             (Value and RAM_Index_Mask);
+         Banked_RAM_Mixin.Select_RAM_Bank
+           (Banked_RAM_Mixin.Banked_RAM_Cart (C), C.Selected_RAM_Bank);
+      end if;
+   end Select_RAM_Bank;
+
+   procedure Select_ROM_Bank (C : in out Camera_Cart; Value : Byte) is
+      use ROM_RAM_Mixin.Banked_ROM_Mixin.Banked_ROM_Spaces;
+   begin
+      C.Select_ROM_Bank (1, Bank_Index (Value and ROM_Index_Mask));
+   end Select_ROM_Bank;
+
+   procedure Stop_Capture (C : in out Camera_Cart) is
+   begin
+      C.Capture_Active := False;
+   end Stop_Capture;
+
+   overriding
+   procedure Write_RAM
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : Byte) is
+   begin
+      if C.Registers_Selected then
+         Write_Register (C, Address, V);
+      elsif C.Capture_Active or else not C.RAM_Write_Enabled then
+         null;
+      else
+         Banked_RAM_Mixin.Write_RAM (Banked_RAM_Mixin.Banked_RAM_Cart (C), Address, V);
+      end if;
+   end Write_RAM;
+
+   procedure Write_Pattern (C : in out Camera_Cart) is
+      Address         : External_RAM_IO_Address;
+      High            : Byte;
+      Low             : Byte;
+      Original_Bank   : constant Banked_RAM_Mixin.Banked_RAM_Spaces.Bank_Index :=
+        C.Selected_RAM_Bank;
+      Original_Select : constant Boolean := C.Registers_Selected;
+      Shade           : Byte;
+      X               : Natural;
+      Y               : Natural;
+   begin
+      Banked_RAM_Mixin.Select_RAM_Bank (Banked_RAM_Mixin.Banked_RAM_Cart (C), 0);
+
+      for Tile_Y in 0 .. (Pattern_Height / 8) - 1 loop
+         for Tile_X in 0 .. (Pattern_Width / 8) - 1 loop
+            for Row in 0 .. 7 loop
+               High := 16#00#;
+               Low := 16#00#;
+
+               for Col in 0 .. 7 loop
+                  X := Tile_X * 8 + Col;
+                  Y := Tile_Y * 8 + Row;
+                  Shade := Pattern_Color (X, Y);
+                  if (Shade and 16#01#) /= 0 then
+                     Low := Low or 2**(7 - Col);
+                  end if;
+                  if (Shade and 16#02#) /= 0 then
+                     High := High or 2**(7 - Col);
+                  end if;
+               end loop;
+
+               Address :=
+                 External_RAM_IO_Address'First
+                 + Word (Pattern_Base_Offset + ((Tile_Y * 16 + Tile_X) * 16) + Row * 2);
+               Banked_RAM_Mixin.Write_RAM
+                 (Banked_RAM_Mixin.Banked_RAM_Cart (C), Address, Low);
+               Banked_RAM_Mixin.Write_RAM
+                 (Banked_RAM_Mixin.Banked_RAM_Cart (C), Address + 1, High);
+            end loop;
+         end loop;
+      end loop;
+
+      Banked_RAM_Mixin.Select_RAM_Bank
+        (Banked_RAM_Mixin.Banked_RAM_Cart (C), Original_Bank);
+      C.Registers_Selected := Original_Select;
+   end Write_Pattern;
+
+   procedure Write_Register
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : Byte)
+   is
+      Idx : constant Natural := Register_Index (Address);
+   begin
+      if Idx = 0 then
+         C.Registers (0) := V and Register_0_Write_Mask;
+         if (V and 16#01#) /= 0 then
+            Resume_Capture (C);
+         else
+            Stop_Capture (C);
+         end if;
+      elsif Idx in Camera_Register_Index then
+         C.Registers (Camera_Register_Index (Idx)) := V;
+      end if;
+   end Write_Register;
+
+end Gade.Carts.Camera;

--- a/core/carts/gade-carts-camera.ads
+++ b/core/carts/gade-carts-camera.ads
@@ -1,4 +1,5 @@
 private with Gade.Carts.Mixins.MBC;
+with Gade.Camera;
 
 package Gade.Carts.Camera is
 
@@ -17,6 +18,10 @@ package Gade.Carts.Camera is
 
    overriding
    procedure Reset (C : in out Camera_Cart);
+
+   overriding
+   procedure Set_Camera_Provider
+     (C : in out Camera_Cart; Provider : Gade.Camera.Provider_Access);
 
    overriding
    procedure Write_RAM
@@ -50,6 +55,7 @@ private
    type Camera_Cart is new MBC_Cart with record
       Capture_Active      : Boolean;
       Capture_Cycles_Left : M_Cycle_Count;
+      Provider            : Gade.Camera.Provider_Access := Gade.Camera.Default_Provider;
       RAM_Write_Enabled   : Boolean;
       Registers           : Camera_Registers;
       Registers_Selected  : Boolean;

--- a/core/carts/gade-carts-camera.ads
+++ b/core/carts/gade-carts-camera.ads
@@ -1,0 +1,80 @@
+private with Gade.Carts.Mixins.MBC;
+
+package Gade.Carts.Camera is
+
+   type Camera_Cart is new Cart with private;
+
+   type Camera_Cart_Access is access Camera_Cart;
+
+   subtype Camera_Cart_NN_Access is not null Camera_Cart_Access;
+
+   overriding
+   procedure Read_RAM
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : out Byte);
+
+   overriding
+   procedure Report_Cycles (C : in out Camera_Cart; Cycles : M_Cycle_Count);
+
+   overriding
+   procedure Reset (C : in out Camera_Cart);
+
+   overriding
+   procedure Write_RAM
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : Byte);
+
+private
+
+   Last_Register         : constant := 16#35#;
+   RAM_Index_Mask        : constant Byte := 16#0F#;
+   RAM_Select_Bit        : constant Byte := 16#10#;
+   Register_0_Read_Mask  : constant Byte := 16#06#;
+   Register_0_Write_Mask : constant Byte := 16#07#;
+   Register_Mirror_Size  : constant := 16#80#;
+   ROM_Bank_Count        : constant := 64;
+   ROM_Index_Mask        : constant Byte := 16#3F#;
+   RAM_Bank_Count        : constant := 16;
+
+   subtype Camera_Register_Index is Natural range 0 .. Last_Register;
+
+   type Camera_Registers is array (Camera_Register_Index) of Byte;
+
+   package MBC_Mixin is new
+     Gade.Carts.Mixins.MBC
+       (Base_Cart => Cart,
+        ROM_Banks => ROM_Bank_Count,
+        RAM_Banks => RAM_Bank_Count);
+   use MBC_Mixin;
+
+   subtype RAM_Bank_Index is ROM_RAM_Mixin.Banked_RAM_Mixin.Banked_RAM_Spaces.Bank_Index;
+
+   type Camera_Cart is new MBC_Cart with record
+      Capture_Active      : Boolean;
+      Capture_Cycles_Left : M_Cycle_Count;
+      RAM_Write_Enabled   : Boolean;
+      Registers           : Camera_Registers;
+      Registers_Selected  : Boolean;
+      Selected_RAM_Bank   : RAM_Bank_Index;
+   end record;
+
+   subtype ROM_Bank_Select_Address is Bank_Select_Address range 16#2000# .. 16#3FFF#;
+
+   subtype RAM_Bank_Select_Address is Bank_Select_Address range 16#4000# .. 16#5FFF#;
+
+   overriding
+   procedure Enable_RAM (C : in out Camera_Cart; Enable : Boolean);
+
+   overriding
+   procedure Select_Bank
+     (C : in out Camera_Cart; Address : Bank_Select_Address; Value : Byte);
+
+   procedure Read_Register
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : out Byte);
+
+   procedure Select_RAM_Bank (C : in out Camera_Cart; Value : Byte);
+
+   procedure Select_ROM_Bank (C : in out Camera_Cart; Value : Byte);
+
+   procedure Write_Register
+     (C : in out Camera_Cart; Address : External_RAM_IO_Address; V : Byte);
+
+end Gade.Carts.Camera;

--- a/core/carts/gade-carts.adb
+++ b/core/carts/gade-carts.adb
@@ -1,13 +1,15 @@
 with Ada.Directories;
 
-with Gade.Carts.Mem.ROM;            use Gade.Carts.Mem.ROM;
-with Gade.Carts.Plain.Constructors; use Gade.Carts.Plain.Constructors;
-with Gade.Carts.MBC1.Constructors;  use Gade.Carts.MBC1.Constructors;
-with Gade.Carts.MBC2.Constructors;  use Gade.Carts.MBC2.Constructors;
-with Gade.Carts.MBC3.Constructors;  use Gade.Carts.MBC3.Constructors;
+with Gade.Carts.Mem.ROM;             use Gade.Carts.Mem.ROM;
+with Gade.Carts.Camera.Constructors; use Gade.Carts.Camera.Constructors;
+with Gade.Carts.Plain.Constructors;  use Gade.Carts.Plain.Constructors;
+with Gade.Carts.MBC1.Constructors;   use Gade.Carts.MBC1.Constructors;
+with Gade.Carts.MBC2.Constructors;   use Gade.Carts.MBC2.Constructors;
+with Gade.Carts.MBC3.Constructors;   use Gade.Carts.MBC3.Constructors;
 
 package body Gade.Carts is
 
+   package Camera_Carts renames Camera.Constructors;
    package Plain_Carts renames Plain.Constructors;
    package MBC1_Carts renames MBC1.Constructors;
    package MBC2_Carts renames MBC2.Constructors;
@@ -51,19 +53,22 @@ package body Gade.Carts is
       Gade.Logging.Info (Logger, "Controller type: " & Controller'Img);
 
       case Controller is
-         when Cartridge_Info.None =>
+         when Cartridge_Info.None          =>
             C := Cart_Access (Plain_Carts.Create (ROM, Header.all, Save_Path, Logger));
 
-         when Cartridge_Info.MBC1 =>
+         when Cartridge_Info.MBC1          =>
             C := Cart_Access (MBC1_Carts.Create (ROM, Header.all, Save_Path, Logger));
 
-         when Cartridge_Info.MBC2 =>
+         when Cartridge_Info.MBC2          =>
             C := Cart_Access (MBC2_Carts.Create (ROM, Header.all, Save_Path, Logger));
 
-         when Cartridge_Info.MBC3 =>
+         when Cartridge_Info.MBC3          =>
             C := Cart_Access (MBC3_Carts.Create (ROM, Header.all, Save_Path, Logger));
 
-         when others              =>
+         when Cartridge_Info.Pocket_Camera =>
+            C := Cart_Access (Camera_Carts.Create (ROM, Header.all, Save_Path, Logger));
+
+         when others                       =>
             C := Cart_Access (Plain_Carts.Create (ROM, Header.all, Save_Path, Logger));
       end case;
       C.Load_RAM;

--- a/core/carts/gade-carts.ads
+++ b/core/carts/gade-carts.ads
@@ -1,5 +1,6 @@
 private with Gade.Cartridge_Info;
 private with Ada.Streams.Stream_IO;
+limited with Gade.Camera;
 with Gade.Logging;
 with Gade.Timing; use Gade.Timing;
 
@@ -155,6 +156,9 @@ private package Gade.Carts is
    function Logger_Of (C : Cart) return Gade.Logging.Logger_Access;
 
    procedure Report_Cycles (C : in out Cart; Cycles : M_Cycle_Count) is null;
+
+   procedure Set_Camera_Provider (C : in out Cart; Provider : Gade.Camera.Provider_Access)
+   is null;
 
 private
 

--- a/core/carts/mixins/gade-carts-mixins-mbc.adb
+++ b/core/carts/mixins/gade-carts-mixins-mbc.adb
@@ -16,7 +16,7 @@ package body Gade.Carts.Mixins.MBC is
       end case;
    end Write_ROM;
 
-   procedure Enable_RAM (C : in out MBC_Cart; V : Byte) is
+   procedure Enable_RAM (C : in out MBC_Cart'Class; V : Byte) is
    begin
       case V and RAM_Enable_Mask is
          when RAM_Enable_Value =>

--- a/core/carts/mixins/gade-carts-mixins-mbc.ads
+++ b/core/carts/mixins/gade-carts-mixins-mbc.ads
@@ -68,7 +68,7 @@ package Gade.Carts.Mixins.MBC is
    overriding
    procedure Write_ROM (C : in out MBC_Cart; Address : External_ROM_IO_Address; V : Byte);
 
-   procedure Enable_RAM (C : in out MBC_Cart; V : Byte);
+   procedure Enable_RAM (C : in out MBC_Cart'Class; V : Byte);
 
    procedure Select_Bank
      (C : in out MBC_Cart; Address : Bank_Select_Address; Value : Byte)

--- a/core/gade-camera.adb
+++ b/core/gade-camera.adb
@@ -1,0 +1,51 @@
+package body Gade.Camera is
+
+   type Pattern_Provider is new Provider_Interface with null record;
+
+   overriding
+   procedure Capture_Frame (Provider : Pattern_Provider; Frame : out Bitmap);
+
+   function Pattern_Color (X : Column_Index; Y : Row_Index) return Pixel_Value;
+
+   Pattern_Provider_Instance : aliased Pattern_Provider;
+   Default                   : constant Provider_Access :=
+     Pattern_Provider_Instance'Access;
+
+   procedure Capture_Frame (Provider : Provider_Access; Frame : out Bitmap) is
+      Effective_Provider : constant Provider_Access :=
+        (if Provider = null then Default_Provider else Provider);
+   begin
+      Effective_Provider.Capture_Frame (Frame);
+   end Capture_Frame;
+
+   overriding
+   procedure Capture_Frame (Provider : Pattern_Provider; Frame : out Bitmap) is
+      pragma Unreferenced (Provider);
+   begin
+      for Y in Frame'Range (1) loop
+         for X in Frame'Range (2) loop
+            Frame (Y, X) := Pattern_Color (X, Y);
+         end loop;
+      end loop;
+   end Capture_Frame;
+
+   function Default_Provider return Provider_Access is
+   begin
+      return Default;
+   end Default_Provider;
+
+   function Pattern_Color (X : Column_Index; Y : Row_Index) return Pixel_Value is
+      In_Border : constant Boolean :=
+        X < 8
+        or else X >= Capture_Width - 8
+        or else Y < 8
+        or else Y >= Capture_Height - 8;
+   begin
+      if In_Border then
+         return 3;
+      else
+         return Pixel_Value ((X / 32) mod 4);
+      end if;
+   end Pattern_Color;
+
+end Gade.Camera;

--- a/core/gade-camera.adb
+++ b/core/gade-camera.adb
@@ -1,6 +1,6 @@
 package body Gade.Camera is
 
-   type Pattern_Provider is new Provider_Interface with null record;
+   type Pattern_Provider is limited new Provider_Interface with null record;
 
    overriding
    procedure Capture_Frame (Provider : Pattern_Provider; Frame : out Bitmap);
@@ -10,6 +10,13 @@ package body Gade.Camera is
    Pattern_Provider_Instance : aliased Pattern_Provider;
    Default                   : constant Provider_Access :=
      Pattern_Provider_Instance'Access;
+
+   procedure Set_Capture_Active (Provider : Provider_Access; Active : Boolean) is
+      Effective_Provider : constant Provider_Access :=
+        (if Provider = null then Default_Provider else Provider);
+   begin
+      Effective_Provider.Set_Capture_Active (Active);
+   end Set_Capture_Active;
 
    procedure Capture_Frame (Provider : Provider_Access; Frame : out Bitmap) is
       Effective_Provider : constant Provider_Access :=

--- a/core/gade-camera.ads
+++ b/core/gade-camera.ads
@@ -11,7 +11,10 @@ package Gade.Camera is
 
    type Bitmap is array (Row_Index, Column_Index) of Pixel_Value;
 
-   type Provider_Interface is interface;
+   type Provider_Interface is limited interface;
+
+   procedure Set_Capture_Active (Provider : in out Provider_Interface; Active : Boolean)
+   is null;
 
    procedure Capture_Frame (Provider : Provider_Interface; Frame : out Bitmap)
    is abstract;
@@ -19,6 +22,8 @@ package Gade.Camera is
    type Provider_Access is access all Provider_Interface'Class;
 
    function Default_Provider return Provider_Access;
+
+   procedure Set_Capture_Active (Provider : Provider_Access; Active : Boolean);
 
    procedure Capture_Frame (Provider : Provider_Access; Frame : out Bitmap);
 

--- a/core/gade-camera.ads
+++ b/core/gade-camera.ads
@@ -1,0 +1,25 @@
+with Interfaces;
+
+package Gade.Camera is
+
+   Capture_Height : constant := 112;
+   Capture_Width  : constant := 128;
+
+   subtype Column_Index is Natural range 0 .. Capture_Width - 1;
+   subtype Pixel_Value is Interfaces.Unsigned_8 range 0 .. 3;
+   subtype Row_Index is Natural range 0 .. Capture_Height - 1;
+
+   type Bitmap is array (Row_Index, Column_Index) of Pixel_Value;
+
+   type Provider_Interface is interface;
+
+   procedure Capture_Frame (Provider : Provider_Interface; Frame : out Bitmap)
+   is abstract;
+
+   type Provider_Access is access all Provider_Interface'Class;
+
+   function Default_Provider return Provider_Access;
+
+   procedure Capture_Frame (Provider : Provider_Access; Frame : out Bitmap);
+
+end Gade.Camera;

--- a/core/gade-interfaces.adb
+++ b/core/gade-interfaces.adb
@@ -1,6 +1,7 @@
 with Ada.Unchecked_Deallocation;
 
 with Gade.GB;             use Gade.GB;
+with Gade.Camera;
 with Gade.Input;          use Gade.Input;
 with Gade.Audio_Buffer;   use Gade.Audio_Buffer;
 with Gade.Video_Buffer;   use Gade.Video_Buffer;
@@ -12,17 +13,21 @@ with Gade.Carts;
 with Gade.Logging;
 
 package body Gade.Interfaces is
+   use type Gade.Camera.Provider_Access;
    use type Gade.Logging.Logger_Access;
    use type Gade.Dev.CPU.CPU_Execution_State;
 
+   procedure Apply_Camera_Provider (G : Gade_Type);
+
    type Opaque_Gade_Type is record
+      Camera : Gade.Camera.Provider_Access;
       GB     : Gade.GB.GB_Type;
       Logger : Gade.Logging.Logger_Access;
    end record;
 
    procedure Create (G : out Gade_Type) is
    begin
-      Create (G, null, null);
+      Create (G, null, null, null);
    end Create;
 
    procedure Create
@@ -30,10 +35,21 @@ package body Gade.Interfaces is
       Reader : Gade.Input.Reader_Access;
       Logger : Gade.Logging.Logger_Access) is
    begin
+      Create (G, Reader, Logger, null);
+   end Create;
+
+   procedure Create
+     (G      : out Gade_Type;
+      Reader : Gade.Input.Reader_Access;
+      Logger : Gade.Logging.Logger_Access;
+      Camera : Gade.Camera.Provider_Access) is
+   begin
       G := new Opaque_Gade_Type;
+      G.Camera := (if Camera = null then Gade.Camera.Default_Provider else Camera);
       G.Logger := (if Logger = null then Gade.Logging.Default_Logger else Logger);
       G.GB.Create (G.Logger);
       G.GB.Joypad.Set_Input_Reader (Reader);
+      Apply_Camera_Provider (G);
    end Create;
 
    procedure Reset (G : Gade_Type) is
@@ -41,15 +57,28 @@ package body Gade.Interfaces is
       G.GB.Reset;
    end Reset;
 
+   procedure Apply_Camera_Provider (G : Gade_Type) is
+   begin
+      G.GB.Cart.Set_Camera_Provider (G.Camera);
+   end Apply_Camera_Provider;
+
    procedure Load_ROM (G : Gade_Type; Path : String) is
    begin
       G.GB.Cart := Gade.Carts.Load_ROM (Path, G.Logger);
+      Apply_Camera_Provider (G);
    end Load_ROM;
 
    procedure Set_Input_Reader (G : Gade_Type; Reader : Gade.Input.Reader_Access) is
    begin
       G.GB.Joypad.Set_Input_Reader (Reader);
    end Set_Input_Reader;
+
+   procedure Set_Camera_Provider (G : Gade_Type; Provider : Gade.Camera.Provider_Access)
+   is
+   begin
+      G.Camera := (if Provider = null then Gade.Camera.Default_Provider else Provider);
+      Apply_Camera_Provider (G);
+   end Set_Camera_Provider;
 
    procedure Run_For
      (G                 : Gade_Type;

--- a/core/gade-interfaces.ads
+++ b/core/gade-interfaces.ads
@@ -1,3 +1,4 @@
+limited with Gade.Camera;
 limited with Gade.Input;
 limited with Gade.Logging;
 limited with Gade.Video_Buffer;
@@ -20,7 +21,8 @@ package Gade.Interfaces is
 
    type Gade_Type is private;
 
-   --  Create a new emulator instance with default input reader and logger.
+   --  Create a new emulator instance with neutral input, the default camera
+   --  provider and the default logger.
    --
    --  Ownership:
    --  - The returned handle is owned by the caller and must be released with
@@ -34,11 +36,13 @@ package Gade.Interfaces is
    --
    --  Nullability:
    --  - Reader may be null (treated as "no input pressed").
+   --  - Camera may be null (Default_Provider is used).
    --  - Logger may be null (Default_Logger is used).
    --
    --  Ownership:
-   --  - The caller retains ownership of Reader and Logger.
-   --  - Reader and Logger must remain valid while attached to this instance.
+   --  - The caller retains ownership of Reader, Camera and Logger.
+   --  - Reader, Camera and Logger must remain valid while attached to this
+   --    instance.
    --  - The returned handle is owned by the caller and must be released with
    --    Finalize exactly once.
    --
@@ -48,6 +52,12 @@ package Gade.Interfaces is
      (G      : out Gade_Type;
       Reader : Gade.Input.Reader_Access;
       Logger : Gade.Logging.Logger_Access);
+
+   procedure Create
+     (G      : out Gade_Type;
+      Reader : Gade.Input.Reader_Access;
+      Logger : Gade.Logging.Logger_Access;
+      Camera : Gade.Camera.Provider_Access);
 
    --  Reset emulator state (CPU, memory-mapped devices, and loaded cartridge
    --  runtime state) to power-on defaults.
@@ -94,6 +104,25 @@ package Gade.Interfaces is
    --    exceptions.
    procedure Set_Input_Reader (G : Gade_Type; Reader : Gade.Input.Reader_Access);
 
+   --  Set or replace the camera provider used by camera cartridges.
+   --
+   --  Nullability:
+   --  - Provider may be null to detach custom capture and restore the default
+   --    static-pattern provider.
+   --
+   --  Preconditions:
+   --  - G must be a non-null handle previously returned by Create and not
+   --    finalized yet.
+   --
+   --  Ownership:
+   --  - The caller retains ownership of Provider and must keep it valid while
+   --    attached.
+   --
+   --  Error behavior:
+   --  - Invalid handles (for example null/dangling) raise runtime access-check
+   --    exceptions.
+   procedure Set_Camera_Provider (G : Gade_Type; Provider : Gade.Camera.Provider_Access);
+
    --  Execute emulation until a frame is completed or Requested_Samples are
    --  generated, whichever happens first.
    --
@@ -133,7 +162,7 @@ package Gade.Interfaces is
    --
    --  Ownership:
    --  - Releases resources owned by G and sets G to null.
-   --  - Does not free caller-owned Reader/Logger implementations.
+   --  - Does not free caller-owned Reader/Camera/Logger implementations.
    --
    --  Error behavior:
    --  - Save I/O exceptions propagate to caller.

--- a/cpp/cameraprovider.hpp
+++ b/cpp/cameraprovider.hpp
@@ -1,0 +1,13 @@
+#ifndef cameraprovider_hpp
+#define cameraprovider_hpp
+
+#include <stdint.h>
+
+class CameraProvider {
+public:
+    virtual ~CameraProvider() {}
+
+    virtual void captureFrame(uint8_t *bitmap) = 0;
+};
+
+#endif /* cameraprovider_hpp */

--- a/cpp/cameraprovider.hpp
+++ b/cpp/cameraprovider.hpp
@@ -7,6 +7,10 @@ class CameraProvider {
 public:
     virtual ~CameraProvider() {}
 
+    virtual void setCaptureActive(bool active) {
+        (void)active;
+    }
+
     virtual void captureFrame(uint8_t *bitmap) = 0;
 };
 

--- a/cpp/gade-interfaces-c.adb
+++ b/cpp/gade-interfaces-c.adb
@@ -3,33 +3,61 @@ with Ada.Unchecked_Deallocation;
 
 package body Gade.Interfaces.C is
 
+   type Flat_Bitmap is
+     array (0 .. Gade.Camera.Capture_Height * Gade.Camera.Capture_Width - 1)
+     of unsigned_char;
+   pragma Convention (C, Flat_Bitmap);
+
+   procedure Free_Camera_Provider is new
+     Ada.Unchecked_Deallocation
+       (Object => Camera_Provider_Wrapper,
+        Name   => Camera_Provider_Wrapper_Access);
+
+   procedure Free_Input_Reader is new
+     Ada.Unchecked_Deallocation
+       (Object => Input_Reader_Wrapper,
+        Name   => Input_Reader_Wrapper_Access);
+
+   procedure Free_State is new
+     Ada.Unchecked_Deallocation (Object => C_State, Name => C_State_Access);
+
+   function To_Pixel_Value (Value : unsigned_char) return Gade.Camera.Pixel_Value;
+
    procedure Initialize (This : out Gade_Type) is
    begin
-      Gade.Interfaces.Create (This.G);
-      This.Input_Reader := null;
+      This.Vptr := System.Null_Address;
+      This.State := new C_State;
+      Gade.Interfaces.Create (This.State.G);
+   exception
+      when others =>
+         if This.State /= null then
+            Free_State (This.State);
+         end if;
+         raise;
    end Initialize;
 
    procedure Finalize (This : in out Gade_Type) is
-      procedure Free_Input_Reader is new
-        Ada.Unchecked_Deallocation
-          (Object => Input_Reader_Wrapper,
-           Name   => Input_Reader_Wrapper_Access);
    begin
-      Gade.Interfaces.Set_Input_Reader (This.G, null);
-      if This.Input_Reader /= null then
-         Free_Input_Reader (This.Input_Reader);
+      Gade.Interfaces.Set_Camera_Provider (This.State.G, null);
+      Gade.Interfaces.Set_Input_Reader (This.State.G, null);
+      if This.State.Camera_Provider /= null then
+         Free_Camera_Provider (This.State.Camera_Provider);
       end if;
-      Gade.Interfaces.Finalize (This.G);
+      if This.State.Input_Reader /= null then
+         Free_Input_Reader (This.State.Input_Reader);
+      end if;
+      Gade.Interfaces.Finalize (This.State.G);
+      Free_State (This.State);
    end Finalize;
 
    procedure Reset (This : Gade_Type) is
    begin
-      Gade.Interfaces.Reset (This.G);
+      Gade.Interfaces.Reset (This.State.G);
    end Reset;
 
    procedure Load_ROM (This : Gade_Type; ROM_File : chars_ptr) is
    begin
-      Gade.Interfaces.Load_ROM (This.G, Value (ROM_File));
+      Gade.Interfaces.Load_ROM (This.State.G, Value (ROM_File));
    end Load_ROM;
 
    procedure Run_For
@@ -50,10 +78,30 @@ package body Gade.Interfaces.C is
          Requested := Positive (Requested_Samples);
       end if;
 
-      Gade.Interfaces.Run_For (This.G, Requested, Generated, Video, Audio, Finished);
+      Gade.Interfaces.Run_For
+        (This.State.G, Requested, Generated, Video, Audio, Finished);
       Generated_Samples := unsigned (Generated);
       Frame_Finished := (if Finished then 1 else 0);
    end Run_For;
+
+   type Camera_Provider_Class is null record;
+
+   procedure Capture_Frame (This : Camera_Provider_Class_Access; Bitmap : System.Address);
+   pragma Import (C, Capture_Frame, "CameraProvider_captureFrame");
+
+   overriding
+   procedure Capture_Frame (Wrapper : Camera_Provider_Wrapper; Frame : out Bitmap) is
+      Flat  : aliased Flat_Bitmap;
+      Index : Natural := Flat'First;
+   begin
+      Capture_Frame (Wrapper.C_Instance, Flat'Address);
+      for Y in Frame'Range (1) loop
+         for X in Frame'Range (2) loop
+            Frame (Y, X) := To_Pixel_Value (Flat (Index));
+            Index := Index + 1;
+         end loop;
+      end loop;
+   end Capture_Frame;
 
    type Input_Reader_Class is null record;
 
@@ -71,15 +119,11 @@ package body Gade.Interfaces.C is
    procedure Set_Input_Reader
      (This : in out Gade_Type; Input_Reader : Input_Reader_Class_Access)
    is
-      procedure Free_Input_Reader is new
-        Ada.Unchecked_Deallocation
-          (Object => Input_Reader_Wrapper,
-           Name   => Input_Reader_Wrapper_Access);
       Wrapper : Input_Reader_Wrapper_Access;
    begin
-      Gade.Interfaces.Set_Input_Reader (This.G, null);
-      if This.Input_Reader /= null then
-         Free_Input_Reader (This.Input_Reader);
+      Gade.Interfaces.Set_Input_Reader (This.State.G, null);
+      if This.State.Input_Reader /= null then
+         Free_Input_Reader (This.State.Input_Reader);
       end if;
 
       if Input_Reader = null then
@@ -88,9 +132,30 @@ package body Gade.Interfaces.C is
 
       Wrapper := new Input_Reader_Wrapper;
       Wrapper.C_Instance := Input_Reader;
-      This.Input_Reader := Wrapper;
-      Gade.Interfaces.Set_Input_Reader (This.G, Gade.Input.Reader_Access (Wrapper));
+      This.State.Input_Reader := Wrapper;
+      Gade.Interfaces.Set_Input_Reader (This.State.G, Gade.Input.Reader_Access (Wrapper));
    end Set_Input_Reader;
+
+   procedure Set_Camera_Provider
+     (This : in out Gade_Type; Camera_Provider : Camera_Provider_Class_Access)
+   is
+      Wrapper : Camera_Provider_Wrapper_Access;
+   begin
+      Gade.Interfaces.Set_Camera_Provider (This.State.G, null);
+      if This.State.Camera_Provider /= null then
+         Free_Camera_Provider (This.State.Camera_Provider);
+      end if;
+
+      if Camera_Provider = null then
+         return;
+      end if;
+
+      Wrapper := new Camera_Provider_Wrapper;
+      Wrapper.C_Instance := Camera_Provider;
+      This.State.Camera_Provider := Wrapper;
+      Gade.Interfaces.Set_Camera_Provider
+        (This.State.G, Gade.Camera.Provider_Access (Wrapper));
+   end Set_Camera_Provider;
 
    procedure Next_Frame (This : Gade_Type; Video : RGB32_Display_Buffer_Access) is
       Audio             : aliased Frame_Audio_Buffer;
@@ -105,5 +170,14 @@ package body Gade.Interfaces.C is
          Audio'Unchecked_Access,
          Frame_Finished);
    end Next_Frame;
+
+   function To_Pixel_Value (Value : unsigned_char) return Gade.Camera.Pixel_Value is
+   begin
+      if Value > unsigned_char (Gade.Camera.Pixel_Value'Last) then
+         return Gade.Camera.Pixel_Value'Last;
+      else
+         return Gade.Camera.Pixel_Value (Value);
+      end if;
+   end To_Pixel_Value;
 
 end Gade.Interfaces.C;

--- a/cpp/gade-interfaces-c.adb
+++ b/cpp/gade-interfaces-c.adb
@@ -86,8 +86,19 @@ package body Gade.Interfaces.C is
 
    type Camera_Provider_Class is null record;
 
+   procedure Set_Capture_Active
+     (This : Camera_Provider_Class_Access; Active : unsigned_char);
+   pragma Import (C, Set_Capture_Active, "CameraProvider_setCaptureActive");
+
    procedure Capture_Frame (This : Camera_Provider_Class_Access; Bitmap : System.Address);
    pragma Import (C, Capture_Frame, "CameraProvider_captureFrame");
+
+   overriding
+   procedure Set_Capture_Active
+     (Wrapper : in out Camera_Provider_Wrapper; Active : Boolean) is
+   begin
+      Set_Capture_Active (Wrapper.C_Instance, (if Active then 1 else 0));
+   end Set_Capture_Active;
 
    overriding
    procedure Capture_Frame (Wrapper : Camera_Provider_Wrapper; Frame : out Bitmap) is

--- a/cpp/gade-interfaces-c.ads
+++ b/cpp/gade-interfaces-c.ads
@@ -4,6 +4,7 @@ with Gade.Video_Buffer; use Gade.Video_Buffer;
 with System;
 with Interfaces.C;         use Interfaces.C;
 with Interfaces.C.Strings; use Interfaces.C.Strings;
+with Gade.Camera;          use Gade.Camera;
 with Gade.Input;           use Gade.Input;
 
 package Gade.Interfaces.C is
@@ -40,17 +41,40 @@ package Gade.Interfaces.C is
      (This : in out Gade_Type; Input_Reader : Input_Reader_Class_Access);
    pragma Export (C, Set_Input_Reader, "gadeSetInputReader");
 
+   type Camera_Provider_Class_Access is private;
+
+   procedure Set_Camera_Provider
+     (This : in out Gade_Type; Camera_Provider : Camera_Provider_Class_Access);
+   pragma Export (C, Set_Camera_Provider, "gadeSetCameraProvider");
+
 private
+
+   type C_State;
+   type C_State_Access is access all C_State;
+
+   type Camera_Provider_Wrapper;
+   type Camera_Provider_Wrapper_Access is access all Camera_Provider_Wrapper;
 
    type Input_Reader_Wrapper;
    type Input_Reader_Wrapper_Access is access all Input_Reader_Wrapper;
 
    type Gade_Type is record
-      Vptr         : System.Address;
-      G            : Gade.Interfaces.Gade_Type;
-      Input_Reader : Input_Reader_Wrapper_Access;
+      Vptr  : System.Address;
+      State : C_State_Access;
    end record;
    pragma Convention (C, Gade_Type);
+
+   type Camera_Provider_Class;
+
+   type Camera_Provider_Class_Access is access all Camera_Provider_Class;
+   pragma Convention (C, Camera_Provider_Class_Access);
+
+   type Camera_Provider_Wrapper is new Provider_Interface with record
+      C_Instance : Camera_Provider_Class_Access;
+   end record;
+
+   overriding
+   procedure Capture_Frame (Wrapper : Camera_Provider_Wrapper; Frame : out Bitmap);
 
    type Input_Reader_Class;
 
@@ -63,5 +87,11 @@ private
 
    overriding
    function Read_Input (Wrapper : Input_Reader_Wrapper) return State;
+
+   type C_State is record
+      Camera_Provider : Camera_Provider_Wrapper_Access := null;
+      G               : Gade.Interfaces.Gade_Type;
+      Input_Reader    : Input_Reader_Wrapper_Access := null;
+   end record;
 
 end Gade.Interfaces.C;

--- a/cpp/gade-interfaces-c.ads
+++ b/cpp/gade-interfaces-c.ads
@@ -69,9 +69,13 @@ private
    type Camera_Provider_Class_Access is access all Camera_Provider_Class;
    pragma Convention (C, Camera_Provider_Class_Access);
 
-   type Camera_Provider_Wrapper is new Provider_Interface with record
+   type Camera_Provider_Wrapper is limited new Provider_Interface with record
       C_Instance : Camera_Provider_Class_Access;
    end record;
+
+   overriding
+   procedure Set_Capture_Active
+     (Wrapper : in out Camera_Provider_Wrapper; Active : Boolean);
 
    overriding
    procedure Capture_Frame (Wrapper : Camera_Provider_Wrapper; Frame : out Bitmap);

--- a/cpp/libgade.cpp
+++ b/cpp/libgade.cpp
@@ -12,8 +12,16 @@ void gadeRunFor(GB *gb,
                 RGB32Bitmap *videoBuf,
                 StereoSample *audioBuf,
                 uint8_t *frameFinished);
+void gadeSetCameraProvider(GB *gb, CameraProvider *cameraProviderInstance);
 void gadeSetInputReader(GB *gb, InputReader *inputReaderInstance);
+void CameraProvider_captureFrame(CameraProvider *cameraProviderInstance,
+                                 uint8_t *bitmap);
 uint8_t InputReader_readInput(InputReader *inputReaderInstance);
+}
+
+void CameraProvider_captureFrame(CameraProvider *cameraProviderInstance,
+                                 uint8_t *bitmap) {
+    cameraProviderInstance->captureFrame(bitmap);
 }
 
 uint8_t InputReader_readInput(InputReader *inputReaderInstance) {
@@ -75,4 +83,9 @@ void GB::runFor(uint32_t requestedSamples,
 EXPORT
 void GB::setInputReader(InputReader *inputReader) {
     gadeSetInputReader(this, inputReader);
+}
+
+EXPORT
+void GB::setCameraProvider(CameraProvider *cameraProvider) {
+    gadeSetCameraProvider(this, cameraProvider);
 }

--- a/cpp/libgade.cpp
+++ b/cpp/libgade.cpp
@@ -14,9 +14,16 @@ void gadeRunFor(GB *gb,
                 uint8_t *frameFinished);
 void gadeSetCameraProvider(GB *gb, CameraProvider *cameraProviderInstance);
 void gadeSetInputReader(GB *gb, InputReader *inputReaderInstance);
+void CameraProvider_setCaptureActive(CameraProvider *cameraProviderInstance,
+                                     uint8_t active);
 void CameraProvider_captureFrame(CameraProvider *cameraProviderInstance,
                                  uint8_t *bitmap);
 uint8_t InputReader_readInput(InputReader *inputReaderInstance);
+}
+
+void CameraProvider_setCaptureActive(CameraProvider *cameraProviderInstance,
+                                     uint8_t active) {
+    cameraProviderInstance->setCaptureActive(active != 0);
 }
 
 void CameraProvider_captureFrame(CameraProvider *cameraProviderInstance,

--- a/cpp/libgade.hpp
+++ b/cpp/libgade.hpp
@@ -3,12 +3,15 @@
 
 #include <stdint.h>
 
+#include "cameraprovider.hpp"
 #include "inputreader.hpp"
 
 #define EXPORT __attribute__((visibility("default")))
 
 static const uint32_t GB_DISPLAY_WIDTH = 160;
 static const uint32_t GB_DISPLAY_HEIGHT = 144;
+static const uint32_t GB_CAMERA_HEIGHT = 112;
+static const uint32_t GB_CAMERA_WIDTH = 128;
 static const uint32_t GB_CPU_CLOCK_FREQUENCY = 4194304;
 static const uint32_t GB_CPU_M_FREQUENCY = GB_CPU_CLOCK_FREQUENCY / 4;
 static const uint32_t GB_CPU_CYCLES_PER_AUDIO_SAMPLE =
@@ -37,6 +40,7 @@ public:
                 RGB32Bitmap *videoBuf,
                 StereoSample *audioBuf,
                 bool &frameFinished);
+    void setCameraProvider(CameraProvider *cameraProvider);
     void setInputReader(InputReader *inputReader);
 
 private:

--- a/gade.gpr
+++ b/gade.gpr
@@ -14,6 +14,8 @@ library project Gade is
 
    Base_Interfaces :=
      ("gade.ads",
+      "gade-cartridge_info.ads",
+      "gade-carts.ads",
       "gade-logging.ads",
       "gade-interfaces.ads",
       "gade-input.ads",

--- a/gade.gpr
+++ b/gade.gpr
@@ -14,6 +14,7 @@ library project Gade is
 
    Base_Interfaces :=
      ("gade.ads",
+      "gade-camera.ads",
       "gade-cartridge_info.ads",
       "gade-carts.ads",
       "gade-logging.ads",

--- a/gade_cpp.gpr
+++ b/gade_cpp.gpr
@@ -5,7 +5,11 @@ library project Gade_CPP extends "gade.gpr" is
    for Languages use ("Ada", "C++");
    for Interfaces use
      Gade'Interfaces &
-       ("inputreader.hpp", "libgade.hpp", "logger.hpp", "gade-interfaces-c.ads");
+       ("cameraprovider.hpp",
+        "inputreader.hpp",
+        "libgade.hpp",
+        "logger.hpp",
+        "gade-interfaces-c.ads");
    for Library_Name use "gade_cpp";
    for Library_Dir use "lib";
    for Library_Src_Dir use "lib/src/cpp/" & Gade.Gade_Library;

--- a/tests/assets/roms_manifest.toml
+++ b/tests/assets/roms_manifest.toml
@@ -426,3 +426,67 @@ member = "nointro.gb/Pinball Fantasies (USA, Europe).gb"
 encrypted = true
 cache_key = "commercial-roms"
 optional = true
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_16mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_16mb.gb"
+sha256 = "315ac9d9d7a3adda80f5fa8dee5826912bd99961e9539bd39ca8b440464ae794"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_1mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_1mb.gb"
+sha256 = "5170771b8183f7e5e10c2f40d7b3e18d170657b5906305caf111776e2277b425"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_2mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_2mb.gb"
+sha256 = "e93c53a71292b0066cba749a46fde2119b8733580b403189d3987e922588f0ca"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_32mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_32mb.gb"
+sha256 = "665b18d5e876f527e2c05579f7166641539fe895522711906c468f75bd00ec90"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_4mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_4mb.gb"
+sha256 = "188410388f84a5569c2a9f9d6c6e9e269f40d831ea4b718c0ae251d518ecf8c3"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_512kb"
+target = "assets/roms/mooneye/cart_mbc5_rom_512kb.gb"
+sha256 = "6aad3b6b80f5b7308e79ef1acda4a045febe1eddf5021cecc3873d63c3e734ff"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_64mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_64mb.gb"
+sha256 = "e02ff0175932f76e01421a11b202a3840eb4dad70d735819b7dca45aedefe3c5"
+
+[roms.source]
+type = "local_file"
+
+[[roms]]
+id = "mooneye/cart_mbc5_rom_8mb"
+target = "assets/roms/mooneye/cart_mbc5_rom_8mb.gb"
+sha256 = "81e32dc0cfe3940f3be759b1206ac5c46ca42acc64b7848e7de586ec1aa1973e"
+
+[roms.source]
+type = "local_file"

--- a/tests/harness/gade_testd.gpr
+++ b/tests/harness/gade_testd.gpr
@@ -12,7 +12,11 @@ project Gade_Testd is
 
    for Source_Dirs use ("src");
    for Languages use ("Ada");
-   for Main use ("run_tests.adb", "gade_testd.adb", "gade-camera_controller_check.adb");
+   for Main use
+     ("run_tests.adb",
+      "gade_testd.adb",
+      "gade-camera_controller_check.adb",
+      "gade-camera_run_for_check.adb");
    for Exec_Dir use "../bin";
    for Object_Dir use "../obj";
    for Create_Missing_Dirs use "True";
@@ -21,6 +25,7 @@ project Gade_Testd is
    package Builder is
       for Default_Switches ("Ada") use Gade.Builder'Default_Switches ("Ada");
       for Executable ("gade-camera_controller_check") use "gade-camera-controller-check";
+      for Executable ("gade-camera_run_for_check") use "gade-camera-run-for-check";
       for Executable ("run_tests") use "run-tests";
       for Executable ("gade_testd") use "gade-testd";
    end Builder;

--- a/tests/harness/gade_testd.gpr
+++ b/tests/harness/gade_testd.gpr
@@ -12,7 +12,7 @@ project Gade_Testd is
 
    for Source_Dirs use ("src");
    for Languages use ("Ada");
-   for Main use ("run_tests.adb", "gade_testd.adb");
+   for Main use ("run_tests.adb", "gade_testd.adb", "gade-camera_controller_check.adb");
    for Exec_Dir use "../bin";
    for Object_Dir use "../obj";
    for Create_Missing_Dirs use "True";
@@ -20,6 +20,7 @@ project Gade_Testd is
    package Compiler renames Gade.Compiler;
    package Builder is
       for Default_Switches ("Ada") use Gade.Builder'Default_Switches ("Ada");
+      for Executable ("gade-camera_controller_check") use "gade-camera-controller-check";
       for Executable ("run_tests") use "run-tests";
       for Executable ("gade_testd") use "gade-testd";
    end Builder;

--- a/tests/harness/src/gade-camera_controller_check.adb
+++ b/tests/harness/src/gade-camera_controller_check.adb
@@ -1,0 +1,217 @@
+with Ada.Command_Line; use Ada.Command_Line;
+with Ada.Directories;  use Ada.Directories;
+with Ada.Exceptions;   use Ada.Exceptions;
+with Ada.Streams.Stream_IO;
+with Ada.Text_IO;
+
+with Gade.Carts;
+
+procedure Gade.Camera_Controller_Check is
+
+   use Ada.Streams.Stream_IO;
+
+   ROM_Bank_Size : constant := 16#4000#;
+   ROM_Banks     : constant := 64;
+
+   ROM_Path  : constant String := "/tmp/gade-camera-controller-check.gb";
+   Save_Path : constant String := "/tmp/gade-camera-controller-check.sav";
+
+   function Byte_Image (Value : Byte) return String;
+
+   procedure Assert (Condition : Boolean; Message : String);
+
+   procedure Cleanup;
+
+   procedure Create_Test_ROM;
+
+   procedure Expect_RAM
+     (C        : in out Gade.Carts.Cart'Class;
+      Address  : Gade.Carts.External_RAM_IO_Address;
+      Expected : Byte;
+      Label    : String);
+
+   procedure Expect_ROM
+     (C        : in out Gade.Carts.Cart'Class;
+      Address  : Gade.Carts.External_ROM_IO_Address;
+      Expected : Byte;
+      Label    : String);
+
+   function Byte_Image (Value : Byte) return String is
+   begin
+      return Natural'Image (Natural (Value));
+   end Byte_Image;
+
+   procedure Assert (Condition : Boolean; Message : String) is
+   begin
+      if not Condition then
+         raise Program_Error with Message;
+      end if;
+   end Assert;
+
+   procedure Cleanup is
+   begin
+      if Exists (ROM_Path) then
+         Delete_File (ROM_Path);
+      end if;
+      if Exists (Save_Path) then
+         Delete_File (Save_Path);
+      end if;
+   end Cleanup;
+
+   procedure Create_Test_ROM is
+      File   : File_Type;
+      Stream : Stream_Access;
+      Value  : Byte;
+   begin
+      Cleanup;
+      Create (File, Out_File, ROM_Path);
+      Stream := Ada.Streams.Stream_IO.Stream (File);
+
+      for Bank in 0 .. ROM_Banks - 1 loop
+         for Offset in 0 .. ROM_Bank_Size - 1 loop
+            Value := Byte (Bank);
+            if Bank = 0 then
+               case Offset is
+                  when 16#147# =>
+                     Value := 16#FC#;
+
+                  when 16#148# =>
+                     Value := 16#05#;
+
+                  when 16#149# =>
+                     Value := 16#04#;
+
+                  when others  =>
+                     null;
+               end case;
+            end if;
+            Byte'Write (Stream, Value);
+         end loop;
+      end loop;
+
+      Close (File);
+   end Create_Test_ROM;
+
+   procedure Expect_RAM
+     (C        : in out Gade.Carts.Cart'Class;
+      Address  : Gade.Carts.External_RAM_IO_Address;
+      Expected : Byte;
+      Label    : String)
+   is
+      Actual : Byte;
+   begin
+      Gade.Carts.Read_RAM (C, Address, Actual);
+      Assert
+        (Actual = Expected,
+         Label
+         & ": expected"
+         & Byte_Image (Expected)
+         & " got"
+         & Byte_Image (Actual));
+   end Expect_RAM;
+
+   procedure Expect_ROM
+     (C        : in out Gade.Carts.Cart'Class;
+      Address  : Gade.Carts.External_ROM_IO_Address;
+      Expected : Byte;
+      Label    : String)
+   is
+      Actual : Byte;
+   begin
+      Gade.Carts.Read_ROM (C, Address, Actual);
+      Assert
+        (Actual = Expected,
+         Label
+         & ": expected"
+         & Byte_Image (Expected)
+         & " got"
+         & Byte_Image (Actual));
+   end Expect_ROM;
+
+begin
+   Create_Test_ROM;
+
+   declare
+      Cart : constant Gade.Carts.Cart_NN_Access :=
+        Gade.Carts.Load_ROM (ROM_Path, null);
+   begin
+      Expect_ROM (Cart.all, 16#4000#, 16#01#, "initial switchable ROM bank");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#2000#, 16#00#);
+      Expect_ROM (Cart.all, 16#4000#, 16#00#, "ROM bank 0 is selectable");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#2000#, 16#3F#);
+      Expect_ROM
+        (Cart.all, 16#4000#, 16#3F#, "highest camera ROM bank is selectable");
+
+      Expect_RAM
+        (Cart.all, 16#A123#, 16#FF#, "RAM is readable while write-disabled");
+      Gade.Carts.Write_RAM (Cart.all, 16#A123#, 16#12#);
+      Expect_RAM
+        (Cart.all, 16#A123#, 16#FF#, "RAM writes are ignored while disabled");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#0000#, 16#0A#);
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#02#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A123#, 16#55#);
+      Expect_RAM (Cart.all, 16#A123#, 16#55#, "RAM bank write while enabled");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#0000#, 16#00#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A123#, 16#AA#);
+      Expect_RAM (Cart.all, 16#A123#, 16#55#, "RAM writes stop when disabled");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A001#, 16#77#);
+      Expect_RAM
+        (Cart.all, 16#A001#, 16#00#, "camera registers are write-only");
+
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
+      Expect_RAM (Cart.all, 16#A000#, 16#07#, "capture status reads active");
+      Expect_RAM
+        (Cart.all, 16#A080#, 16#07#, "register mirrors expose capture status");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#02#);
+      Expect_RAM
+        (Cart.all, 16#A123#, 16#00#, "active capture blanks RAM reads");
+      Gade.Carts.Write_RAM (Cart.all, 16#A123#, 16#99#);
+      Expect_RAM
+        (Cart.all, 16#A123#, 16#00#, "active capture ignores RAM writes");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#06#);
+      Expect_RAM (Cart.all, 16#A000#, 16#06#, "capture can be paused");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#02#);
+      Expect_RAM
+        (Cart.all, 16#A123#, 16#55#, "paused capture restores RAM reads");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
+      Expect_RAM (Cart.all, 16#A000#, 16#07#, "capture resumes");
+
+      Gade.Carts.Report_Cycles (Cart.all, 40_000);
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Expect_RAM
+        (Cart.all, 16#A000#, 16#06#, "capture completes and clears busy bit");
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#00#);
+      Expect_RAM (Cart.all, 16#A100#, 16#FF#, "pattern row 0 low plane");
+      Expect_RAM (Cart.all, 16#A101#, 16#FF#, "pattern row 0 high plane");
+      Expect_RAM (Cart.all, 16#A210#, 16#00#, "pattern shade 0 low plane");
+      Expect_RAM (Cart.all, 16#A211#, 16#00#, "pattern shade 0 high plane");
+      Expect_RAM (Cart.all, 16#A250#, 16#FF#, "pattern shade 1 low plane");
+      Expect_RAM (Cart.all, 16#A251#, 16#00#, "pattern shade 1 high plane");
+      Expect_RAM (Cart.all, 16#A290#, 16#00#, "pattern shade 2 low plane");
+      Expect_RAM (Cart.all, 16#A291#, 16#FF#, "pattern shade 2 high plane");
+      Expect_RAM (Cart.all, 16#A2D0#, 16#FF#, "pattern shade 3 low plane");
+      Expect_RAM (Cart.all, 16#A2D1#, 16#FF#, "pattern shade 3 high plane");
+   end;
+
+   Cleanup;
+   Ada.Text_IO.Put_Line ("camera controller check passed");
+exception
+   when E : others =>
+      Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, Exception_Message (E));
+      Cleanup;
+      Set_Exit_Status (Failure);
+end Gade.Camera_Controller_Check;

--- a/tests/harness/src/gade-camera_controller_check.adb
+++ b/tests/harness/src/gade-camera_controller_check.adb
@@ -17,8 +17,12 @@ procedure Gade.Camera_Controller_Check is
    ROM_Path  : constant String := "/tmp/gade-camera-controller-check.gb";
    Save_Path : constant String := "/tmp/gade-camera-controller-check.sav";
 
-   type Solid_Camera_Provider is new Gade.Camera.Provider_Interface
-   with null record;
+   type Solid_Camera_Provider is limited new Gade.Camera.Provider_Interface
+   with record
+      Activation_Count   : Natural := 0;
+      Deactivation_Count : Natural := 0;
+      Active             : Boolean := False;
+   end record;
 
    function Byte_Image (Value : Byte) return String;
 
@@ -27,6 +31,10 @@ procedure Gade.Camera_Controller_Check is
    overriding
    procedure Capture_Frame
      (Provider : Solid_Camera_Provider; Frame : out Gade.Camera.Bitmap);
+
+   overriding
+   procedure Set_Capture_Active
+     (Provider : in out Solid_Camera_Provider; Active : Boolean);
 
    procedure Cleanup;
 
@@ -68,6 +76,19 @@ procedure Gade.Camera_Controller_Check is
          end loop;
       end loop;
    end Capture_Frame;
+
+   overriding
+   procedure Set_Capture_Active
+     (Provider : in out Solid_Camera_Provider; Active : Boolean) is
+   begin
+      Provider.Active := Active;
+
+      if Active then
+         Provider.Activation_Count := Provider.Activation_Count + 1;
+      else
+         Provider.Deactivation_Count := Provider.Deactivation_Count + 1;
+      end if;
+   end Set_Capture_Active;
 
    procedure Cleanup is
    begin
@@ -190,6 +211,11 @@ begin
       Expect_RAM (Cart.all, 16#A000#, 16#07#, "capture status reads active");
       Expect_RAM
         (Cart.all, 16#A080#, 16#07#, "register mirrors expose capture status");
+      Assert (Provider.Active, "provider is activated when capture starts");
+      Assert
+        (Provider.Activation_Count = 1
+         and then Provider.Deactivation_Count = 0,
+         "provider activation count after first start");
 
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#02#);
       Expect_RAM
@@ -201,6 +227,11 @@ begin
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
       Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#06#);
       Expect_RAM (Cart.all, 16#A000#, 16#06#, "capture can be paused");
+      Assert (not Provider.Active, "provider deactivates when capture pauses");
+      Assert
+        (Provider.Activation_Count = 1
+         and then Provider.Deactivation_Count = 1,
+         "provider activation counts after pause");
 
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#02#);
       Expect_RAM
@@ -209,12 +240,23 @@ begin
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
       Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
       Expect_RAM (Cart.all, 16#A000#, 16#07#, "capture resumes");
+      Assert (Provider.Active, "provider reactivates when capture resumes");
+      Assert
+        (Provider.Activation_Count = 2
+         and then Provider.Deactivation_Count = 1,
+         "provider activation counts after resume");
 
       Gade.Carts.Report_Cycles (Cart.all, 40_000);
 
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
       Expect_RAM
         (Cart.all, 16#A000#, 16#06#, "capture completes and clears busy bit");
+      Assert
+        (not Provider.Active, "provider deactivates when capture completes");
+      Assert
+        (Provider.Activation_Count = 2
+         and then Provider.Deactivation_Count = 2,
+         "provider activation counts after completion");
 
       Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#00#);
       Expect_RAM (Cart.all, 16#A100#, 16#FF#, "pattern row 0 low plane");
@@ -259,6 +301,18 @@ begin
          16#A101#,
          16#FF#,
          "null provider restores default high plane");
+
+      Gade.Carts.Set_Camera_Provider (Cart.all, Provider'Unchecked_Access);
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
+      Assert (Provider.Active, "provider activates again before reset");
+
+      Gade.Carts.Reset (Cart.all);
+      Assert (not Provider.Active, "reset deactivates provider");
+      Assert
+        (Provider.Activation_Count = 3
+         and then Provider.Deactivation_Count = 3,
+         "provider activation counts after reset");
    end;
 
    Cleanup;

--- a/tests/harness/src/gade-camera_controller_check.adb
+++ b/tests/harness/src/gade-camera_controller_check.adb
@@ -4,6 +4,7 @@ with Ada.Exceptions;   use Ada.Exceptions;
 with Ada.Streams.Stream_IO;
 with Ada.Text_IO;
 
+with Gade.Camera;
 with Gade.Carts;
 
 procedure Gade.Camera_Controller_Check is
@@ -16,9 +17,16 @@ procedure Gade.Camera_Controller_Check is
    ROM_Path  : constant String := "/tmp/gade-camera-controller-check.gb";
    Save_Path : constant String := "/tmp/gade-camera-controller-check.sav";
 
+   type Solid_Camera_Provider is new Gade.Camera.Provider_Interface
+   with null record;
+
    function Byte_Image (Value : Byte) return String;
 
    procedure Assert (Condition : Boolean; Message : String);
+
+   overriding
+   procedure Capture_Frame
+     (Provider : Solid_Camera_Provider; Frame : out Gade.Camera.Bitmap);
 
    procedure Cleanup;
 
@@ -47,6 +55,19 @@ procedure Gade.Camera_Controller_Check is
          raise Program_Error with Message;
       end if;
    end Assert;
+
+   overriding
+   procedure Capture_Frame
+     (Provider : Solid_Camera_Provider; Frame : out Gade.Camera.Bitmap)
+   is
+      pragma Unreferenced (Provider);
+   begin
+      for Y in Frame'Range (1) loop
+         for X in Frame'Range (2) loop
+            Frame (Y, X) := 2;
+         end loop;
+      end loop;
+   end Capture_Frame;
 
    procedure Cleanup is
    begin
@@ -132,8 +153,9 @@ begin
    Create_Test_ROM;
 
    declare
-      Cart : constant Gade.Carts.Cart_NN_Access :=
+      Cart     : constant Gade.Carts.Cart_NN_Access :=
         Gade.Carts.Load_ROM (ROM_Path, null);
+      Provider : aliased Solid_Camera_Provider;
    begin
       Expect_ROM (Cart.all, 16#4000#, 16#01#, "initial switchable ROM bank");
 
@@ -205,6 +227,38 @@ begin
       Expect_RAM (Cart.all, 16#A291#, 16#FF#, "pattern shade 2 high plane");
       Expect_RAM (Cart.all, 16#A2D0#, 16#FF#, "pattern shade 3 low plane");
       Expect_RAM (Cart.all, 16#A2D1#, 16#FF#, "pattern shade 3 high plane");
+
+      Gade.Carts.Set_Camera_Provider (Cart.all, Provider'Unchecked_Access);
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
+      Gade.Carts.Report_Cycles (Cart.all, 40_000);
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#00#);
+      Expect_RAM (Cart.all, 16#A100#, 16#00#, "custom frame row 0 low plane");
+      Expect_RAM (Cart.all, 16#A101#, 16#FF#, "custom frame row 0 high plane");
+      Expect_RAM
+        (Cart.all, 16#A2D0#, 16#00#, "custom frame keeps low plane cleared");
+      Expect_RAM
+        (Cart.all, 16#A2D1#, 16#FF#, "custom frame keeps high plane set");
+
+      Gade.Carts.Set_Camera_Provider (Cart.all, null);
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#10#);
+      Gade.Carts.Write_RAM (Cart.all, 16#A000#, 16#07#);
+      Gade.Carts.Report_Cycles (Cart.all, 40_000);
+
+      Gade.Carts.Write_ROM (Cart.all, 16#4000#, 16#00#);
+      Expect_RAM
+        (Cart.all,
+         16#A100#,
+         16#FF#,
+         "null provider restores default low plane");
+      Expect_RAM
+        (Cart.all,
+         16#A101#,
+         16#FF#,
+         "null provider restores default high plane");
    end;
 
    Cleanup;

--- a/tests/harness/src/gade-camera_controller_check.ads
+++ b/tests/harness/src/gade-camera_controller_check.ads
@@ -1,0 +1,1 @@
+private procedure Gade.Camera_Controller_Check;

--- a/tests/harness/src/gade-camera_run_for_check.adb
+++ b/tests/harness/src/gade-camera_run_for_check.adb
@@ -1,0 +1,272 @@
+with Ada.Command_Line; use Ada.Command_Line;
+with Ada.Directories;  use Ada.Directories;
+with Ada.Exceptions;   use Ada.Exceptions;
+with Ada.Streams.Stream_IO;
+with Ada.Text_IO;
+
+with Gade.Audio_Buffer; use Gade.Audio_Buffer;
+with Gade.Camera;
+with Gade.Interfaces;   use Gade.Interfaces;
+with Gade.Video_Buffer; use Gade.Video_Buffer;
+
+procedure Gade.Camera_Run_For_Check is
+
+   use Ada.Streams.Stream_IO;
+
+   ROM_Bank_Size : constant := 16#4000#;
+   ROM_Banks     : constant := 64;
+
+   Bank_Size : constant := 16#2000#;
+
+   ROM_Path  : constant String := "/tmp/gade-camera-run-for-check.gb";
+   Save_Path : constant String := "/tmp/gade-camera-run-for-check.sav";
+
+   Trigger_Program : constant array (Natural range 0 .. 57) of Byte :=
+     [16#3E#,
+      16#0A#,
+      16#EA#,
+      16#00#,
+      16#00#,
+      16#3E#,
+      16#10#,
+      16#EA#,
+      16#00#,
+      16#40#,
+      16#AF#,
+      16#EA#,
+      16#02#,
+      16#A0#,
+      16#3E#,
+      16#30#,
+      16#EA#,
+      16#03#,
+      16#A0#,
+      16#3E#,
+      16#07#,
+      16#EA#,
+      16#00#,
+      16#A0#,
+      16#FA#,
+      16#00#,
+      16#A0#,
+      16#E6#,
+      16#01#,
+      16#20#,
+      16#F9#,
+      16#AF#,
+      16#EA#,
+      16#00#,
+      16#40#,
+      16#FA#,
+      16#00#,
+      16#A1#,
+      16#47#,
+      16#FA#,
+      16#01#,
+      16#A1#,
+      16#4F#,
+      16#3E#,
+      16#01#,
+      16#EA#,
+      16#00#,
+      16#40#,
+      16#78#,
+      16#EA#,
+      16#00#,
+      16#A0#,
+      16#79#,
+      16#EA#,
+      16#01#,
+      16#A0#,
+      16#18#,
+      16#FE#];
+
+   type Solid_Camera_Provider is limited new Gade.Camera.Provider_Interface
+   with null record;
+
+   function Byte_Image (Value : Byte) return String;
+
+   procedure Assert (Condition : Boolean; Message : String);
+
+   procedure Cleanup;
+
+   procedure Create_Test_ROM;
+
+   procedure Expect_Save_Byte
+     (Offset : Natural; Expected : Byte; Label : String);
+
+   procedure Run_Frame
+     (G     : Gade_Type;
+      Video : RGB32_Display_Buffer_Access;
+      Audio : Audio_Buffer_Access);
+
+   overriding
+   procedure Capture_Frame
+     (Provider : Solid_Camera_Provider; Frame : out Gade.Camera.Bitmap);
+
+   function Byte_Image (Value : Byte) return String is
+   begin
+      return Natural'Image (Natural (Value));
+   end Byte_Image;
+
+   procedure Assert (Condition : Boolean; Message : String) is
+   begin
+      if not Condition then
+         raise Program_Error with Message;
+      end if;
+   end Assert;
+
+   procedure Cleanup is
+   begin
+      if Exists (ROM_Path) then
+         Delete_File (ROM_Path);
+      end if;
+      if Exists (Save_Path) then
+         Delete_File (Save_Path);
+      end if;
+   end Cleanup;
+
+   overriding
+   procedure Capture_Frame
+     (Provider : Solid_Camera_Provider; Frame : out Gade.Camera.Bitmap)
+   is
+      pragma Unreferenced (Provider);
+   begin
+      for Y in Frame'Range (1) loop
+         for X in Frame'Range (2) loop
+            Frame (Y, X) := 2;
+         end loop;
+      end loop;
+   end Capture_Frame;
+
+   procedure Create_Test_ROM is
+      File   : File_Type;
+      Stream : Stream_Access;
+      Value  : Byte;
+   begin
+      Cleanup;
+      Create (File, Out_File, ROM_Path);
+      Stream := Ada.Streams.Stream_IO.Stream (File);
+
+      for Bank in 0 .. ROM_Banks - 1 loop
+         for Offset in 0 .. ROM_Bank_Size - 1 loop
+            Value := 16#00#;
+
+            if Bank = 0 then
+               case Offset is
+                  when 16#0100# .. 16#0100# + Trigger_Program'Last =>
+                     Value := Trigger_Program (Offset - 16#0100#);
+
+                  when 16#0147#                                    =>
+                     Value := 16#FC#;
+
+                  when 16#0148#                                    =>
+                     Value := 16#05#;
+
+                  when 16#0149#                                    =>
+                     Value := 16#04#;
+
+                  when others                                      =>
+                     null;
+               end case;
+            end if;
+
+            Byte'Write (Stream, Value);
+         end loop;
+      end loop;
+
+      Close (File);
+   end Create_Test_ROM;
+
+   procedure Expect_Save_Byte
+     (Offset : Natural; Expected : Byte; Label : String)
+   is
+      File   : File_Type;
+      Stream : Stream_Access;
+      Actual : Byte;
+   begin
+      Open (File, In_File, Save_Path);
+      Set_Index (File, Positive_Count (Offset + 1));
+      Stream := Ada.Streams.Stream_IO.Stream (File);
+      Byte'Read (Stream, Actual);
+      Close (File);
+
+      Assert
+        (Actual = Expected,
+         Label
+         & ": expected"
+         & Byte_Image (Expected)
+         & " got"
+         & Byte_Image (Actual));
+   end Expect_Save_Byte;
+
+   procedure Run_Frame
+     (G     : Gade_Type;
+      Video : RGB32_Display_Buffer_Access;
+      Audio : Audio_Buffer_Access)
+   is
+      Requested_Samples : constant Positive := 2_048;
+      Generated_Samples : Natural;
+      Frame_Finished    : Boolean := False;
+   begin
+      while not Frame_Finished loop
+         Run_For
+           (G,
+            Requested_Samples,
+            Generated_Samples,
+            Video,
+            Audio,
+            Frame_Finished);
+      end loop;
+   end Run_Frame;
+
+begin
+   Create_Test_ROM;
+
+   declare
+      Audio    : aliased Frame_Audio_Buffer;
+      Created  : Boolean := False;
+      G        : Gade_Type;
+      Provider : aliased Solid_Camera_Provider;
+      Video    : aliased RGB32_Display_Buffer;
+   begin
+      Gade.Interfaces.Create (G);
+      Set_Camera_Provider (G, Provider'Unchecked_Access);
+      Created := True;
+      Load_ROM (G, ROM_Path);
+      Reset (G);
+
+      for I in 1 .. 4 loop
+         Run_Frame (G, Video'Unchecked_Access, Audio'Unchecked_Access);
+      end loop;
+
+      Finalize (G);
+      Created := False;
+
+      Assert (Exists (Save_Path), "expected save file to be created");
+
+      Expect_Save_Byte (16#0100#, 16#00#, "captured low plane in bank 0");
+      Expect_Save_Byte (16#0101#, 16#FF#, "captured high plane in bank 0");
+      Expect_Save_Byte (Bank_Size + 16#0000#, 16#00#, "CPU copied low plane");
+      Expect_Save_Byte (Bank_Size + 16#0001#, 16#FF#, "CPU copied high plane");
+   exception
+      when others =>
+         if Created then
+            begin
+               Finalize (G);
+            exception
+               when others =>
+                  null;
+            end;
+         end if;
+         raise;
+   end;
+
+   Cleanup;
+   Ada.Text_IO.Put_Line ("camera run_for check passed");
+exception
+   when E : others =>
+      Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, Exception_Message (E));
+      Cleanup;
+      Set_Exit_Status (Failure);
+end Gade.Camera_Run_For_Check;

--- a/tests/integration/misc/test_camera_controller.py
+++ b/tests/integration/misc/test_camera_controller.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python3
+
+import subprocess
+
+
+def test_camera_controller_check(tests_root, harness_exe):
+    del harness_exe
+
+    exe = tests_root / "bin" / "gade-camera-controller-check"
+    proc = subprocess.run(
+        [str(exe)],
+        cwd=str(tests_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="ascii",
+        errors="replace",
+        check=False,
+    )
+
+    assert proc.returncode == 0, (
+        "camera controller check failed\n"
+        "stdout:\n{}\n"
+        "stderr:\n{}".format(proc.stdout, proc.stderr)
+    )

--- a/tests/integration/misc/test_camera_run_for.py
+++ b/tests/integration/misc/test_camera_run_for.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python3
+
+import subprocess
+
+
+def test_camera_run_for_check(tests_root, harness_exe):
+    del harness_exe
+
+    exe = tests_root / "bin" / "gade-camera-run-for-check"
+    proc = subprocess.run(
+        [str(exe)],
+        cwd=str(tests_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding="ascii",
+        errors="replace",
+        check=False,
+    )
+
+    assert proc.returncode == 0, (
+        "camera run_for check failed\n"
+        "stdout:\n{}\n"
+        "stderr:\n{}".format(proc.stdout, proc.stderr)
+    )

--- a/tests/interfaces/cpp/libgade_cpp_interface_check.cpp
+++ b/tests/interfaces/cpp/libgade_cpp_interface_check.cpp
@@ -1,5 +1,14 @@
 #include "libgade.hpp"
 
+class NullCameraProvider final : public CameraProvider {
+public:
+    void captureFrame(uint8_t *bitmap) override {
+        for (uint32_t i = 0; i < GB_CAMERA_HEIGHT * GB_CAMERA_WIDTH; ++i) {
+            bitmap[i] = 0;
+        }
+    }
+};
+
 class NullInputReader final : public InputReader {
 public:
     unsigned char readButtons() override {
@@ -9,6 +18,7 @@ public:
 
 int main() {
     GB gb;
+    NullCameraProvider camera;
     NullInputReader input;
 
     RGB32Bitmap video[GB_DISPLAY_HEIGHT][GB_DISPLAY_WIDTH] = {};
@@ -16,6 +26,7 @@ int main() {
     uint32_t generatedSamples = 0;
     bool frameFinished = false;
 
+    gb.setCameraProvider(&camera);
     gb.setInputReader(&input);
     gb.runFor(1, generatedSamples, &video[0][0], &audio[0], frameFinished);
     gb.reset();


### PR DESCRIPTION
Implemented the Game Boy Camera cart controller against the PanDocs behavior described at https://gbdev.io/pandocs/Gameboy_Camera.html.

The main controller lives in `Gade.Carts.Camera`. It reuses the existing MBC/ROM-RAM mixins, adds the camera-specific register window selection and capture state, keeps RAM readable while write-disabled, blanks RAM reads and ignores RAM writes during capture, and writes a static 128x112 test pattern into SRAM bank 0 when capture completes.